### PR TITLE
Seal Vmm Class

### DIFF
--- a/vmmsharp/vmmsharp.cs
+++ b/vmmsharp/vmmsharp.cs
@@ -276,7 +276,7 @@ namespace vmmsharp
         }
     }
 
-    public class Vmm : IDisposable
+    public sealed class Vmm : IDisposable
     {
         //---------------------------------------------------------------------
         // CORE FUNCTIONALITY BELOW:
@@ -399,7 +399,7 @@ namespace vmmsharp
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!this.disposed)
             {


### PR DESCRIPTION
RE: Vmmsharp implementation

Per https://github.com/dotnet/runtime/issues/49944

There is a decent performance benefit to sealing classes that do not need to be inherited.

Due to the low level nature of this class (and the rapid sequence of method calls), I found it advantageous to seal Vmm. Especially since it does not implement any virtual methods that can be overridden (besides Dispose).