### PR TITLE
Panama support

### DIFF
--- a/vmmjava/.idea/.gitignore
+++ b/vmmjava/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/vmmjava/vmm/internal/VmmImpl.java
+++ b/vmmjava/vmm/internal/VmmImpl.java
@@ -1,6 +1,9 @@
 package vmm.internal;
 
+import java.io.File;
+import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,21 +22,27 @@ import vmm.internal.VmmNative.VMMDLL_REGISTRY_HIVE_INFORMATION;
  * @author Ulf Frisk - pcileech@frizk.net
  */
 public class VmmImpl implements IVmm
-{ 
-	
+{
+
 	//-----------------------------------------------------------------------------
 	// INITIALIZATION FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
 	private Pointer hVMM = null;
 	private String vmmNativeLibraryPath = null;
-	
+
+	private VmmImplPanama panamaImpl;
+
+
 	/*
 	 * Do not allow direct class instantiation from outside.
 	 */
 	private VmmImpl()
 	{
 	}
-	
+
+	// TODO: Should be determined on runtime whether panama can be used, if not fall back to JNA impl
+	public static boolean USE_PANAMA = false;
+
 	private VmmImpl(String vmmNativeLibraryPath, String argv[])
 	{
 		String[] argv_new = null;
@@ -52,38 +61,44 @@ public class VmmImpl implements IVmm
 		if(hVMM == null) { throw new VmmException("Vmm Init: failed in native code."); }
 		VmmNative.INSTANCE.VMMDLL_InitializePlugins(hVMM);
 		this.vmmNativeLibraryPath = vmmNativeLibraryPath;
+		if (USE_PANAMA) {
+			panamaImpl = new VmmImplPanama(MemorySegment.ofAddress(Pointer.nativeValue(hVMM)));
+		}
 	}
-	
+
 	public static IVmm Initialize(String vmmNativeLibraryPath, String argv[])
 	{
 		return new VmmImpl(vmmNativeLibraryPath, argv);
 	}
-	
+
 	public boolean isValid() {
 		return hVMM != null;
 	}
 
 	public String getNativeLibraryPath() {
 		return vmmNativeLibraryPath;
-	}	
-	
+	}
+
 	public void close()
 	{
+		if (USE_PANAMA) {
+			panamaImpl.close();
+		}
 		VmmNative.INSTANCE.VMMDLL_Close(hVMM);
 		hVMM = null;
 	}
-	
+
 	/*
 	 * Always close native implementation upon finalization.
 	 */
 	@Override
 	public void finalize()
 	{
-	    try {
-	        this.close();
-	    } catch (Exception e) {}
+		try {
+			this.close();
+		} catch (Exception e) {}
 	}
-	
+
 	/*
 	 * Custom toString() method.
 	 */
@@ -92,33 +107,33 @@ public class VmmImpl implements IVmm
 	{
 		return (hVMM != null) ? "Vmm" : "VmmNotValid";
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// CONFIGURATION SETTINGS BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	public long getConfig(long fOption)
 	{
 		LongByReference pqw = new LongByReference();
 		boolean f = VmmNative.INSTANCE.VMMDLL_ConfigGet(hVMM, fOption, pqw);
 		if(!f) { throw new VmmException(); }
-		return pqw.getValue(); 
+		return pqw.getValue();
 	}
-	
+
 	public void setConfig(long fOption, long qw)
 	{
 		boolean f = VmmNative.INSTANCE.VMMDLL_ConfigSet(hVMM, fOption, qw);
 		if(!f) { throw new VmmException(); }
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// INTERNAL UTILITY FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private static byte[] _utilStringToCString(String s)
 	{
 		byte[] bjava = s.getBytes(StandardCharsets.UTF_8);
@@ -126,15 +141,15 @@ public class VmmImpl implements IVmm
 		System.arraycopy(bjava, 0, bc, 0, bjava.length);
 		return bc;
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// VFS - VIRTUAL FILE SYSTEM FUNCTIONALITY BELOW:
 	// NB! VFS FUNCTIONALITY REQUIRES PLUGINS TO BE INITIALIZED
-	//     WITH CALL TO InitializePlugins(). 
+	//     WITH CALL TO InitializePlugins().
 	//-----------------------------------------------------------------------------
-	
+
 	public List<Vmm_VfsListEntry> vfsList(String path)
 	{
 		ArrayList<Vmm_VfsListEntry> result = new ArrayList<Vmm_VfsListEntry>();
@@ -165,7 +180,7 @@ public class VmmImpl implements IVmm
 		if(!f) { throw new VmmException(); }
 		return result;
 	}
-	
+
 	public byte[] vfsRead(String file, long offset, int size)
 	{
 		IntByReference pcbRead = new IntByReference();
@@ -177,13 +192,13 @@ public class VmmImpl implements IVmm
 		pb.read(0, result, 0, size);
 		return result;
 	}
-	
+
 	public String vfsReadString(String file, long offset, int size)
 	{
 		byte[] data = vfsRead(file, offset, size);
 		return new String(data, StandardCharsets.UTF_8);
 	}
-	
+
 	public void vfsWrite(String file, byte[] data, long offset)
 	{
 		IntByReference pcbWrite = new IntByReference();
@@ -192,25 +207,25 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_VfsWriteU(hVMM, _utilStringToCString(file), pb, data.length, pcbWrite, offset);
 		if(0 == pcbWrite.getValue()) { throw new VmmException(); }
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// INTERNAL VMM MEMORY FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private class VmmMemScatterMemoryImpl implements IVmmMemScatterMemory {
 		private final Object objLock = new Object();
 		private Pointer hS;
 		private int pid;
 		private int flags;
-		
+
 		private VmmMemScatterMemoryImpl(Pointer hS, int pid, int flags) {
 			this.hS = hS;
 			this.pid = pid;
 			this.flags = flags;
 		}
-		
+
 		@Override
 		public String toString()
 		{
@@ -220,7 +235,7 @@ public class VmmImpl implements IVmm
 				return "VmmScatterMemory:Virtual:" + String.valueOf(pid);
 			}
 		}
-		
+
 		public boolean isValid() {
 			return this.hS != null;
 		}
@@ -231,30 +246,49 @@ public class VmmImpl implements IVmm
 
 		public void prepare(long va, int size) {
 			if(this.hS == null) { throw new VmmException(); }
+			if (USE_PANAMA) {
+				panamaImpl.scatterPrepare(MemorySegment.ofAddress(Pointer.nativeValue(hS)), va, size);
+				return;
+			}
 			boolean f = VmmNative.INSTANCE.VMMDLL_Scatter_Prepare(hS, va, size);
-			if(!f) { throw new VmmException(); }				
+			if(!f) { throw new VmmException(); }
 		}
 
 		public void prepareWrite(long va, byte[] data) {
 			if(this.hS == null) { throw new VmmException(); }
+			if (USE_PANAMA) {
+				panamaImpl.scatterPrepareWrite(MemorySegment.ofAddress(Pointer.nativeValue(hS)), va, data);
+				return;
+			}
 			boolean f = VmmNative.INSTANCE.VMMDLL_Scatter_PrepareWrite(hS, va, data, data.length);
 			if(!f) { throw new VmmException(); }
 		}
 
 		public void execute() {
 			if(this.hS == null) { throw new VmmException(); }
+			if (USE_PANAMA) {
+				panamaImpl.scatterExecute(MemorySegment.ofAddress(Pointer.nativeValue(hS)));
+				return;
+			}
 			boolean f = VmmNative.INSTANCE.VMMDLL_Scatter_Execute(hS);
 			if(!f) { throw new VmmException(); }
 		}
 
 		public void clear() {
 			if(this.hS == null) { throw new VmmException(); }
+			if (USE_PANAMA) {
+				panamaImpl.scatterClear(MemorySegment.ofAddress(Pointer.nativeValue(hS)), pid, flags);
+				return;
+			}
 			boolean f = VmmNative.INSTANCE.VMMDLL_Scatter_Clear(hS, pid, flags);
 			if(!f) { throw new VmmException(); }
 		}
 
 		public byte[] read(long va, int size) {
 			if(this.hS == null) { throw new VmmException(); }
+			if (USE_PANAMA) {
+				return panamaImpl.scatterRead(MemorySegment.ofAddress(Pointer.nativeValue(hS)), va, size);
+			}
 			IntByReference pcbRead = new IntByReference();
 			byte[] pbResult = new byte[size];
 			boolean f = VmmNative.INSTANCE.VMMDLL_Scatter_Read(hS, va, size, pbResult, pcbRead);
@@ -272,42 +306,50 @@ public class VmmImpl implements IVmm
 				}
 			}
 		}
-		
+
 		@Override
 		public void finalize()
 		{
-		    try {
-		        this.close();
-		    } catch (Exception e) {}
+			try {
+				this.close();
+			} catch (Exception e) {}
 		}
 	}
-	
+
 	public byte[] _memRead(int pid, long va, int size)
 	{
 		return _memRead(pid, va, size, 0);
 	}
-	
+
 	public byte[] _memRead(int pid, long va, int size, int flags)
 	{
+		if (USE_PANAMA) {
+			return panamaImpl.memRead(pid, va, size, flags);
+		}
+
 		IntByReference pcbRead = new IntByReference();
 		byte[] pbResult = new byte[size];
 		boolean f = VmmNative.INSTANCE.VMMDLL_MemReadEx(hVMM, pid, va, pbResult, size, pcbRead, flags);
 		if(!f) { throw new VmmException(); }
 		return pbResult;
 	}
-	
+
 	public void _memWrite(int pid, long va, byte[] data)
 	{
+		if (USE_PANAMA) {
+			panamaImpl.memWrite(pid, va, data);
+			return;
+		}
 		boolean f = VmmNative.INSTANCE.VMMDLL_MemWrite(hVMM, pid, va, data, data.length);
 		if(!f) { throw new VmmException(); }
 	}
-	
+
 	public void _memPrefetchPages(int pid, long[] vas)
 	{
 		boolean f = VmmNative.INSTANCE.VMMDLL_MemPrefetchPages(hVMM, pid, vas, vas.length);
-		if(!f) { throw new VmmException(); }		
+		if(!f) { throw new VmmException(); }
 	}
-	
+
 	public long _memVirtualToPhysical(int pid, long va)
 	{
 		LongByReference pa = new LongByReference();
@@ -322,13 +364,13 @@ public class VmmImpl implements IVmm
 		if(hS == null) { throw new VmmException(); }
 		return new VmmMemScatterMemoryImpl(hS, pid, flags);
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// VMM PHYSICAL MEMORY FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	public byte[] memRead(long pa, int size)
 	{
 		return _memRead(-1, pa, size);
@@ -351,28 +393,28 @@ public class VmmImpl implements IVmm
 	public IVmmMemScatterMemory memScatterInitialize(int flags) {
 		return _memScatterInitialize(-1, flags);
 	}
-	
-	
-		
+
+
+
 	//-----------------------------------------------------------------------------
 	// VMM INTERNAL PDB/DEBUG FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private class VmmPdbImpl implements IVmmPdb
 	{
 		private String pdbName;
-		
+
 		private VmmPdbImpl(int dwPID, long vaModuleBase) {
 			byte[] szModuleName = new byte[VmmNative.MAX_PATH];
 			boolean f = VmmNative.INSTANCE.VMMDLL_PdbLoad(hVMM, dwPID, vaModuleBase, szModuleName);
 			if(!f) { throw new VmmException(); }
 			this.pdbName = Native.toString(szModuleName);
 		}
-		
+
 		private VmmPdbImpl(String pdbName) {
 			this.pdbName = pdbName;
 		}
-		
+
 		@Override
 		public String toString() {
 			return "VmmPdb:" + pdbName;
@@ -411,9 +453,9 @@ public class VmmImpl implements IVmm
 			return pcbTypeSize.getValue();
 		}
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// VMM KERNEL FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
@@ -432,13 +474,13 @@ public class VmmImpl implements IVmm
 	{
 		return (int)getConfig(OPT_WIN_VERSION_BUILD);
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// VMM MAP FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	public List<VmmMap_MemMapEntry> mapPhysicalMemory()
 	{
 		PointerByReference pptr = new PointerByReference();
@@ -456,7 +498,7 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_MemFree(pptr.getValue());
 		return result;
 	}
-	
+
 	public List<VmmMap_NetEntry> mapNet()
 	{
 		PointerByReference pptr = new PointerByReference();
@@ -485,7 +527,7 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_MemFree(pptr.getValue());
 		return result;
 	}
-	
+
 	public List<VmmMap_UserEntry> mapUser()
 	{
 		PointerByReference pptr = new PointerByReference();
@@ -504,7 +546,7 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_MemFree(pptr.getValue());
 		return result;
 	}
-	
+
 	public List<VmmMap_ServiceEntry> mapService()
 	{
 		PointerByReference pptr = new PointerByReference();
@@ -537,7 +579,7 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_MemFree(pptr.getValue());
 		return result;
 	}
-	
+
 	public VmmMap_PoolMap mapPool(boolean isBigPoolOnly)
 	{
 		int flags = isBigPoolOnly ? VmmNative.VMMDLL_POOLMAP_FLAG_BIG : VmmNative.VMMDLL_POOLMAP_FLAG_ALL;
@@ -569,23 +611,23 @@ public class VmmImpl implements IVmm
 		VmmNative.INSTANCE.VMMDLL_MemFree(pptr.getValue());
 		return result;
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// PROCESS INTERNAL FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private class VmmProcessImpl implements IVmmProcess
 	{
 		private int pid;
 		private VmmNative.VMMDLL_PROCESS_INFORMATION info;
-		
+
 		private VmmProcessImpl(int pid) {
 			this.pid = pid;
 			this.info = null;
 		}
-		
+
 		/*
 		 * Ensure process information is loaded
 		 */
@@ -602,12 +644,12 @@ public class VmmImpl implements IVmm
 				this.info = pInfo;
 			}
 		}
-		
+
 		@Override
 		public String toString() {
 			return "VmmProcess:" + String.valueOf(pid);
 		}
-		
+
 		public int getPID() {
 			return pid;
 		}
@@ -862,7 +904,7 @@ public class VmmImpl implements IVmm
 			ensure();
 			return info.paDTB;
 		}
-		
+
 		public long getDTBUser() {
 			ensure();
 			return info.paDTB_UserOpt;
@@ -909,7 +951,7 @@ public class VmmImpl implements IVmm
 			VmmNative.INSTANCE.VMMDLL_MemFree(p);
 			return s;
 		}
-		
+
 		public String getCmdLine() {
 			Pointer p = VmmNative.INSTANCE.VMMDLL_ProcessGetInformationString(hVMM, pid, VmmNative.VMMDLL_PROCESS_INFORMATION_OPT_STRING_CMDLINE);
 			String s = p.getString(0);
@@ -1004,9 +1046,9 @@ public class VmmImpl implements IVmm
 			return result;
 		}
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// VMM PROCESS FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
@@ -1023,7 +1065,7 @@ public class VmmImpl implements IVmm
 		IntByReference pdwPID = new IntByReference();
 		boolean f = VmmNative.INSTANCE.VMMDLL_PidGetFromName(hVMM, _utilStringToCString(name), pdwPID);
 		if(!f) { throw new VmmException(); }
-		return new VmmProcessImpl(pdwPID.getValue()); 
+		return new VmmProcessImpl(pdwPID.getValue());
 	}
 
 	public List<IVmmProcess> processGetAll()
@@ -1043,13 +1085,13 @@ public class VmmImpl implements IVmm
 		}
 		return result;
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// MODULE INTERNAL FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private class VmmModuleImpl implements IVmmModule
 	{
 		private IVmmProcess process;
@@ -1057,8 +1099,8 @@ public class VmmImpl implements IVmm
 		private VmmNative.VMMDLL_MAP_MODULEENTRY module;
 		private VmmNative.VMMDLL_MAP_MODULEENTRY_DEBUGINFO debug;
 		private VmmNative.VMMDLL_MAP_MODULEENTRY_VERSIONINFO version;
-		
-		
+
+
 		private VmmModuleImpl(IVmmProcess process, VmmNative.VMMDLL_MAP_MODULEENTRY module, VmmNative.VMMDLL_MAP_MODULEENTRY_DEBUGINFO debug, VmmNative.VMMDLL_MAP_MODULEENTRY_VERSIONINFO version) {
 			this.module = module;
 			this.debug = debug;
@@ -1066,7 +1108,7 @@ public class VmmImpl implements IVmm
 			this.process = process;
 			this.pid = process.getPID();
 		}
-		
+
 		@Override
 		public String toString() {
 			return "VmmModule:" + String.valueOf(pid) + ":" + module.uszText;
@@ -1079,7 +1121,7 @@ public class VmmImpl implements IVmm
 		public String getName() {
 			return module.uszText;
 		}
-		
+
 		public String getNameFull() {
 			return module.uszFullName;
 		}
@@ -1095,7 +1137,7 @@ public class VmmImpl implements IVmm
 		public int getSize() {
 			return module.cbImageSize;
 		}
-		
+
 		public int getSizeFile() {
 			return module.cbFileSizeRaw;
 		}
@@ -1115,7 +1157,7 @@ public class VmmImpl implements IVmm
 		public int getCountIAT() {
 			return module.cIAT;
 		}
-			
+
 		public Vmm_ModuleExDebugInfo getExDebugInfo() {
 			if(debug == null) {
 				return null;
@@ -1127,7 +1169,7 @@ public class VmmImpl implements IVmm
 			n.PdbFilename = debug.uszPdbFilename;
 			return n;
 		}
-		
+
 		public Vmm_ModuleExVersionInfo getExVersionInfo() {
 			if(version == null) {
 				return null;
@@ -1167,7 +1209,7 @@ public class VmmImpl implements IVmm
 			}
 			return result;
 		}
-		
+
 		public List<VmmMap_ModuleSection> mapSection() {
 			IntByReference pcData = new IntByReference();
 			boolean f = VmmNative.INSTANCE.VMMDLL_ProcessGetSectionsU(hVMM, pid, module.uszText, null, 0, pcData);
@@ -1245,21 +1287,21 @@ public class VmmImpl implements IVmm
 			return new VmmImpl.VmmPdbImpl(pid, module.vaBase);
 		}
 	}
-	
-	
-	
+
+
+
 	//-----------------------------------------------------------------------------
 	// REGISTRY INTERNAL FUNCTIONALITY BELOW:
 	//-----------------------------------------------------------------------------
-	
+
 	private class VmmRegHiveImpl implements IVmmRegHive {
 		private VmmNative.VMMDLL_REGISTRY_HIVE_INFORMATION hive;
-		
+
 		VmmRegHiveImpl(VmmNative.VMMDLL_REGISTRY_HIVE_INFORMATION hive)
 		{
 			this.hive = hive;
 		}
-		
+
 		@Override
 		public String toString() {
 			return String.format("VmmRegHive:0x%016x", hive.vaCMHIVE);
@@ -1276,7 +1318,7 @@ public class VmmImpl implements IVmm
 		public String getPath() {
 			return Native.toString(hive.uszHiveRootPath);
 		}
-		
+
 		public int getSize() {
 			return hive.cbLength;
 		}
@@ -1288,7 +1330,7 @@ public class VmmImpl implements IVmm
 		public long getVaBaseBlock() {
 			return hive.vaHBASE_BLOCK;
 		}
-		
+
 		public byte[] memRead(int ra, int size) {
 			return memRead(ra, size, 0);
 		}
@@ -1319,17 +1361,17 @@ public class VmmImpl implements IVmm
 			return new VmmRegKeyImpl(strKeyPath);
 		}
 	}
-	
+
 	private class VmmRegKeyImpl implements IVmmRegKey {
 		private String strPath;
 		private String strName;
-		
+
 		private VmmRegKeyImpl(String strPath)
 		{
 			strName = strPath.substring(strPath.lastIndexOf('\\') + 1);
 			this.strPath = strPath;
 		}
-		
+
 		@Override
 		public String toString() {
 			return "VmmRegKey:" + strName;
@@ -1387,19 +1429,19 @@ public class VmmImpl implements IVmm
 			return lpftLastWriteTime.getValue();
 		}
 	}
-	
+
 	private class VmmRegValueImpl implements IVmmRegValue {
 		private String strPath;
 		private String strName;
 		private int dwType;
-		
+
 		private VmmRegValueImpl(String strPath, int dwType)
 		{
 			this.strName = strPath.substring(strPath.lastIndexOf('\\') + 1);
 			this.strPath = strPath;
 			this.dwType = dwType;
 		}
-		
+
 		@Override
 		public String toString() {
 			return "VmmRegValue:" + strName;
@@ -1448,7 +1490,7 @@ public class VmmImpl implements IVmm
 		public int getType() {
 			return dwType;
 		}
-		
+
 	}
 
 	public List<IVmmRegHive> regHive() {

--- a/vmmjava/vmm/internal/VmmImplPanama.java
+++ b/vmmjava/vmm/internal/VmmImplPanama.java
@@ -1,0 +1,231 @@
+package vmm.internal;
+
+import vmm.VmmException;
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+
+import static java.lang.foreign.ValueLayout.*;
+
+public class VmmImplPanama {
+
+    // 256 kb
+    private final int PRE_ALLOCATED_SEGMENT_SIZE = 0x40000;
+
+    private final Arena arena = Arena.ofShared();
+    private final Linker linker = Linker.nativeLinker();
+    private final SymbolLookup lookup = SymbolLookup.libraryLookup("vmm.dll", arena);
+
+    private MemorySegment vmmHandle;
+
+    private MemorySegment dataBufferSegment;
+    private MemorySegment refSegment;
+
+    private VmmMethodHandles methodHandles;
+
+    private VmmImplPanama() {
+
+    }
+
+    public VmmImplPanama(MemorySegment vmmHandle) {
+        this.vmmHandle = vmmHandle;
+        dataBufferSegment = arena.allocateArray(JAVA_BYTE, PRE_ALLOCATED_SEGMENT_SIZE);
+        refSegment = arena.allocate(ADDRESS);
+        methodHandles = new VmmMethodHandles();
+        methodHandles.initialize();
+    }
+
+    public byte[] memRead(int pid, long va, int size, int flags) {
+        if (size > PRE_ALLOCATED_SEGMENT_SIZE) {
+            Arena dynamicArena = Arena.ofShared();
+            MemorySegment dataBufferSegment = dynamicArena.allocateArray(JAVA_BYTE, size);
+            byte[] bytes = memRead(pid, va, size, flags, dataBufferSegment);
+            dynamicArena.close();
+            return bytes;
+        }
+        return memRead(pid, va, size, flags, dataBufferSegment);
+    }
+
+
+
+    private byte[] memRead(int pid, long va, int size, int flags, MemorySegment dataBufferSegment) {
+        boolean successful = (boolean) invokeUnchecked(methodHandles.memRead, vmmHandle, pid, va, dataBufferSegment, size, refSegment, flags);
+        if (!successful) {
+            throw new VmmException();
+        }
+        return getBytes(size, dataBufferSegment);
+    }
+
+    public void memWrite(int pid, long va, byte[] data) {
+        int size = data.length;
+        if (size > PRE_ALLOCATED_SEGMENT_SIZE) {
+            Arena dynamicArena = Arena.ofShared();
+            MemorySegment dataBufferSegment = dynamicArena.allocateArray(JAVA_BYTE, size);
+            memWrite(pid, va, data, dataBufferSegment);
+            dynamicArena.close();
+        } else {
+            memWrite(pid, va, data, dataBufferSegment);
+        }
+    }
+
+    private void memWrite(int pid, long va, byte[] data, MemorySegment dataBufferSegment) {
+        putBytes(data, dataBufferSegment);
+        boolean successful = (boolean) invokeUnchecked(methodHandles.memWrite, vmmHandle, pid, va, dataBufferSegment, data.length);
+        if (!successful) {
+            throw new VmmException();
+        }
+    }
+
+    public void scatterPrepare(MemorySegment scatterHandle, long va, int size) {
+        boolean successful = (boolean) invokeUnchecked(methodHandles.scatterPrepare, scatterHandle, va, size);
+        if (!successful) {
+            throw new VmmException();
+        }
+    }
+
+    public void scatterPrepareWrite(MemorySegment scatterHandle, long va, byte[] data) {
+        int length = data.length;
+        if (length > PRE_ALLOCATED_SEGMENT_SIZE) {
+            Arena dynamicArena = Arena.ofShared();
+            MemorySegment dataBufferSegment = dynamicArena.allocateArray(JAVA_BYTE, length);
+            scatterPrepareWrite(scatterHandle, va, data, dataBufferSegment);
+            dynamicArena.close();
+        } else {
+            scatterPrepareWrite(scatterHandle, va, data, dataBufferSegment);
+        }
+    }
+
+    private void scatterPrepareWrite(MemorySegment scatterHandle, long va, byte[] data, MemorySegment dataBufferSegment) {
+        putBytes(data, dataBufferSegment);
+        boolean successful = (boolean) invokeUnchecked(methodHandles.scatterPrepareWrite, scatterHandle, va, dataBufferSegment, data.length);
+        if (!successful) {
+            throw new VmmException();
+        }
+    }
+
+    public void scatterExecute(MemorySegment scatterHandle) {
+        boolean successful = (boolean) invokeUnchecked(methodHandles.scatterExecute, scatterHandle);
+        if (!successful) {
+            throw new VmmException();
+        }
+    }
+
+    public void scatterClear(MemorySegment scatterHandle, int pid, int flags) {
+        boolean successful = (boolean) invokeUnchecked(methodHandles.scatterClear, scatterHandle, pid, flags);
+        if (!successful) {
+            throw new VmmException();
+        }
+    }
+
+    public byte[] scatterRead(MemorySegment scatterHandle, long va, int size) {
+        if (size > PRE_ALLOCATED_SEGMENT_SIZE) {
+            Arena dynamicArena = Arena.ofShared();
+            MemorySegment dataBufferSegment = dynamicArena.allocateArray(JAVA_BYTE, size);
+            byte[] bytes = scatterRead(scatterHandle, va, size, dataBufferSegment);
+            dynamicArena.close();
+            return bytes;
+        }
+        return scatterRead(scatterHandle, va, size, dataBufferSegment);
+    }
+
+    private byte[] scatterRead(MemorySegment scatterHandle, long va, int size, MemorySegment dataBufferSegment) {
+        boolean successful = (boolean) invokeUnchecked(methodHandles.scatterRead, scatterHandle, va, size, dataBufferSegment, refSegment);
+        if (!successful) {
+            throw new VmmException();
+        }
+        return getBytes(size, dataBufferSegment);
+    }
+
+    public void close() {
+        arena.close();
+    }
+
+    // TODO: try reading/writing one by one and benchmark if it's faster than to wrap the segment as a ByteBuffer
+    private void putBytes(byte[] data, MemorySegment dest) {
+        dest.asByteBuffer().put(data);
+    }
+
+    private byte[] getBytes(int size, MemorySegment src) {
+        byte[] bytes = new byte[size];
+        src.asByteBuffer().get(bytes);
+        return bytes;
+    }
+
+    // Just a utility function to not have to write try/catch in each invoke call
+    private Object invokeUnchecked(MethodHandle methodHandle, Object... args) {
+        try {
+            return methodHandle.invokeWithArguments(args);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class VmmMethodHandles {
+        private MethodHandle memRead;
+        private MethodHandle memWrite;
+        private MethodHandle scatterPrepare;
+        private MethodHandle scatterPrepareWrite;
+        private MethodHandle scatterExecute;
+        private MethodHandle scatterRead;
+        private MethodHandle scatterClear;
+
+        private void initialize() {
+            initializeMemReadHandle();
+            initializeMemWriteHandle();
+            initializeScatterPrepareHandle();
+            initializeScatterPrepareWriteHandle();
+            initializeScatterExecuteHandle();
+            initializeScatterClearHandle();
+            initializeScatterReadHandle();
+        }
+
+        private void initializeMemReadHandle() {
+            FunctionDescriptor memReadDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_INT, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_INT);
+            memRead = constructMethodHandle("VMMDLL_MemReadEx", memReadDescriptor);
+        }
+
+        private void initializeMemWriteHandle() {
+            FunctionDescriptor memWriteDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_INT, JAVA_LONG, ADDRESS, JAVA_INT);
+            memWrite = constructMethodHandle("VMMDLL_MemWrite", memWriteDescriptor);
+        }
+
+        private void initializeScatterPrepareHandle() {
+            FunctionDescriptor scatterPrepareDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_LONG, JAVA_INT);
+            scatterPrepare = constructMethodHandle("VMMDLL_Scatter_Prepare", scatterPrepareDescriptor);
+        }
+
+        private void initializeScatterPrepareWriteHandle() {
+            FunctionDescriptor scatterPrepareWriteDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_LONG, ADDRESS, JAVA_INT);
+            scatterPrepareWrite = constructMethodHandle("VMMDLL_Scatter_PrepareWrite", scatterPrepareWriteDescriptor);
+        }
+
+        private void initializeScatterExecuteHandle() {
+            FunctionDescriptor scatterExecuteDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS);
+            scatterExecute = constructMethodHandle("VMMDLL_Scatter_Execute", scatterExecuteDescriptor);
+        }
+
+        private void initializeScatterClearHandle() {
+            FunctionDescriptor scatterClearDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_INT, JAVA_INT);
+            scatterClear = constructMethodHandle("VMMDLL_Scatter_Clear", scatterClearDescriptor);
+        }
+
+        private void initializeScatterReadHandle() {
+            FunctionDescriptor scatterReadDescriptor = FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_LONG, JAVA_INT, ADDRESS, ADDRESS);
+            scatterRead = constructMethodHandle("VMMDLL_Scatter_Read", scatterReadDescriptor);
+        }
+
+        /**
+         * Constructs a {@link MethodHandle} from a method name and a {@link FunctionDescriptor}
+         *
+         * @param methodName name of the native method
+         * @param descriptor descriptor of the native method (return type, arguments)
+         * @return the constructed {@link MethodHandle}
+         */
+        private MethodHandle constructMethodHandle(String methodName, FunctionDescriptor descriptor) {
+            MemorySegment memReadEx = lookup.find(methodName).orElseThrow();
+            return linker.downcallHandle(memReadEx, descriptor);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This adds support for calling native code using the new FFM (Project Panama)
As it is still a preview feature (Will be stable in java 22 i believe) the --enable-preview VM option needs to be included.

Currently supported methods are:
```
memRead()
memWrite()
Scatter memory reads/writes
```

Licensed under:
"public domain", "MIT License", "Apache License 2.0", "GNU General Public License v3.0", "GNU Affero General Public License v3.0"