### PR TITLE
Vmmsharp enhancements

### DIFF
--- a/vmmsharp/vmmsharp.cs
+++ b/vmmsharp/vmmsharp.cs
@@ -506,6 +506,7 @@ namespace vmmsharp
             protected override bool ReleaseHandle()
             {
                 lci.LcClose(this.handle);
+                this.handle = IntPtr.Zero;
                 return true;
             }
 
@@ -2268,6 +2269,7 @@ namespace vmmsharp
             protected override bool ReleaseHandle()
             {
                 VMMDLL_Close(this.handle);
+                this.handle = IntPtr.Zero;
                 return true;
             }
 

--- a/vmmsharp/vmmsharp.cs
+++ b/vmmsharp/vmmsharp.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Threading;
+using System.Linq;
 
 /*  
  *  C# API wrapper 'vmmsharp' for MemProcFS 'vmm.dll' and LeechCore 'leechcore.dll' APIs.
@@ -636,6 +637,22 @@ namespace vmmsharp
         public bool ConfigSet(ulong fOption, ulong qwValue)
         {
             return vmmi.VMMDLL_ConfigSet(hVMM, fOption, qwValue);
+        }
+
+        public string GetMemoryMap()
+        {
+            var map = Map_GetPhysMem();
+            if (map.Length == 0)
+                return null;
+            var sb = new StringBuilder();
+            int leftLength = map.Max(x => x.pa).ToString("x").Length;
+            for (int i = 0; i < map.Length; i++)
+            {
+                sb.AppendFormat($"{{0,{-leftLength}}}", map[i].pa.ToString("x"))
+                    .Append($" - {(map[i].pa + map[i].cb - 1).ToString("x")}")
+                    .AppendLine();
+            }
+            return sb.ToString();
         }
 
         //---------------------------------------------------------------------

--- a/vmmsharp/vmmsharp.cs
+++ b/vmmsharp/vmmsharp.cs
@@ -27,7 +27,7 @@ namespace vmmsharp
     }
 
     // LeechCore public API:
-    public class LeechCore : IDisposable
+    public sealed class LeechCore : IDisposable
     {
         //---------------------------------------------------------------------
         // LEECHCORE: PUBLIC API CONSTANTS BELOW:
@@ -267,7 +267,7 @@ namespace vmmsharp
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!this.disposed)
             {
@@ -489,7 +489,7 @@ namespace vmmsharp
 
 
     // MemProcFS public API:
-    public class Vmm : IDisposable
+    public sealed class Vmm : IDisposable
     {
         //---------------------------------------------------------------------
         // CORE FUNCTIONALITY BELOW:
@@ -616,7 +616,7 @@ namespace vmmsharp
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!this.disposed)
             {
@@ -2244,7 +2244,7 @@ namespace vmmsharp
         }
     }
 
-    public class VmmScatter : IDisposable
+    public sealed class VmmScatter : IDisposable
     {
         //---------------------------------------------------------------------
         // MEMORY NEW SCATTER READ/WRITE FUNCTIONALITY BELOW:
@@ -2273,7 +2273,7 @@ namespace vmmsharp
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        private void Dispose(bool disposing)
         {
             if (!this.disposed)
             {

--- a/vmmsharp/vmmsharp.cs
+++ b/vmmsharp/vmmsharp.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
+using System.Threading;
 
 /*  
  *  C# API wrapper 'vmmsharp' for MemProcFS 'vmm.dll' and LeechCore 'leechcore.dll' APIs.
@@ -785,6 +786,22 @@ namespace vmmsharp
             return data;
         }
 
+        public unsafe bool MemReadStruct<T>(uint pid, ulong qwA, out T result, uint flags = 0)
+            where T : unmanaged
+        {
+            uint cb = (uint)sizeof(T);
+            result = default;
+            uint cbRead;
+            fixed (T* pb = &result)
+            {
+                if (!vmmi.VMMDLL_MemReadEx(hVMM, pid, qwA, (byte*)pb, cb, out cbRead, flags))
+                    return false;
+            }
+            if (cbRead != cb)
+                return false;
+            return true;
+        }
+
         public unsafe bool MemPrefetchPages(uint pid, ulong[] qwA)
         {
             byte[] data = new byte[qwA.Length * sizeof(ulong)];
@@ -801,6 +818,14 @@ namespace vmmsharp
             {
                 return vmmi.VMMDLL_MemWrite(hVMM, pid, qwA, pb, (uint)data.Length);
             }
+        }
+
+        public unsafe bool MemWriteStruct<T>(uint pid, ulong qwA, T value)
+            where T : unmanaged
+        {
+            uint cb = (uint)sizeof(T);
+            byte* pb = (byte*)&value;
+            return vmmi.VMMDLL_MemWrite(hVMM, pid, qwA, pb, cb);
         }
 
         public bool MemVirt2Phys(uint dwPID, ulong qwVA, out ulong pqwPA)


### PR DESCRIPTION
- Added basic functionality to read/write struct values (unmanaged only that do not contain reference types)
- Sealed Vmm/Leechcore classes for performance/inlining boost (see https://github.com/dotnet/runtime/issues/49944 )
- Added functionality to get a Memory Map in text format via simple method call.
- Added SafeHandle support for Vmm/Leechcore. The IntPtr is wrapped in a SafeHandle (which implements it's own finalizer), and provides a safe way to access native resources. When disposal is called, the marshaller will wait for existing native interop to complete (while denying any new calls) before releasing the handle fully.

Tested this out and it seems stable.