### PR TITLE
Add `PartialEq`, `Eq` and `Hash` to `LcBar`

### DIFF
--- a/vmmrust/memprocfs/Cargo.toml
+++ b/vmmrust/memprocfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memprocfs"
-version = "5.12.7"
+version = "5.12.8"
 edition = "2021"
 description = "MemProcFS - Physical Memory Analysis Framework"
 homepage = "https://github.com/ufrisk/MemProcFS"

--- a/vmmrust/memprocfs/src/lib_memprocfs.rs
+++ b/vmmrust/memprocfs/src/lib_memprocfs.rs
@@ -3863,7 +3863,7 @@ pub struct LeechCore {
 /// - [`LeechCore::get_bars()`]
 /// - LeechCore PCIe BAR callback.
 /// ```
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct LcBar {
     /// BAR is valid.
     pub is_valid : bool,


### PR DESCRIPTION
Better ergonomics for users of `LcBar` not having to implement on a struct that's consuming it, especially for `Hash/Eq` allows use of `LcBar` within HashSets.


BSD Zero Clause License

Copyright (c) 2024 apekros

Permission to use, copy, modify, and/or distribute this software for any
purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
PERFORMANCE OF THIS SOFTWARE.