### PR TITLE
Vmmsharp improvements

### DIFF
--- a/vmmsharp/vmmsharp/vmmsharp.csproj
+++ b/vmmsharp/vmmsharp/vmmsharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net5.0;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <RootNamespace>Vmmsharp</RootNamespace>

--- a/vmmsharp/vmmsharp/vmmsharp/Internal/Vmmi.cs
+++ b/vmmsharp/vmmsharp/vmmsharp/Internal/Vmmi.cs
@@ -2109,6 +2109,20 @@ namespace Vmmsharp.Internal
             return result;
         }
 
+#if NET9_0_OR_GREATER
+        internal static unsafe bool MemReadRefAs<T>(IntPtr hVMM, uint pid, ulong qwA, out T result, uint flags = 0)
+            where T : unmanaged, allows ref struct
+        {
+            uint cb = (uint)sizeof(T);
+            result = default;
+            fixed (void* pb = &result)
+            {
+                return Vmmi.VMMDLL_MemReadEx(hVMM, pid, qwA, (byte*)pb, cb, out uint cbRead, flags) &&
+                    cbRead == cb;
+            }
+        }
+#endif
+
         internal static unsafe T[] MemReadArray<T>(IntPtr hVMM, uint pid, ulong qwA, uint count, uint flags = 0)
             where T : unmanaged
         {
@@ -2191,6 +2205,9 @@ namespace Vmmsharp.Internal
 
         internal static unsafe bool MemWriteStruct<T>(IntPtr hVMM, uint pid, ulong qwA, T value)
             where T : unmanaged
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
         {
             uint cb = (uint)sizeof(T);
             return Vmmi.VMMDLL_MemWrite(hVMM, pid, qwA, (byte*)&value, cb);
@@ -2211,7 +2228,7 @@ namespace Vmmsharp.Internal
             return Vmmi.VMMDLL_MemVirt2Phys(hVMM, pid, qwVA, out pqwPA);
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/vmmsharp/vmmsharp/vmmsharp/VmmProcess.cs
+++ b/vmmsharp/vmmsharp/vmmsharp/VmmProcess.cs
@@ -228,6 +228,22 @@ namespace Vmmsharp
             where T : unmanaged =>
             Vmmi.MemReadAs<T>(_hVmm, this.PID, va, flags);
 
+#if NET9_0_OR_GREATER
+
+        /// <summary>
+        /// Read Memory from a Virtual Address into a ref struct of Type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">Struct/Ref Struct Type.</typeparam>
+        /// <param name="va">Virtual Address to read from.</param>
+        /// <param name="result">Memory read result.</param>
+        /// <param name="flags">VMM Flags.</param>
+        /// <returns>TRUE if successful, otherwise FALSE.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe bool MemReadRefAs<T>(ulong va, out T result, uint flags = 0)
+            where T : unmanaged, allows ref struct =>
+            Vmmi.MemReadRefAs<T>(_hVmm, this.PID, va, out result, flags);
+#endif
+
         /// <summary>
         /// Read Memory from a Virtual Address into an Array of Type <typeparamref name="T"/>.
         /// </summary>
@@ -334,7 +350,11 @@ namespace Vmmsharp
         /// <returns>True if write successful, otherwise False.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool MemWriteStruct<T>(ulong va, T value)
-            where T : unmanaged =>
+            where T : unmanaged
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+            =>
             Vmmi.MemWriteStruct(_hVmm, this.PID, va, value);
 
         /// <summary>
@@ -362,7 +382,7 @@ namespace Vmmsharp
             Vmmi.MemVirt2Phys(_hVmm, this.PID, va, out pa);
             return pa;
         }
-        #endregion
+#endregion
 
         #region Process Functionality
         /// <summary>

--- a/vmmsharp/vmmsharp/vmmsharp/VmmScatterMemory.cs
+++ b/vmmsharp/vmmsharp/vmmsharp/VmmScatterMemory.cs
@@ -155,6 +155,9 @@ namespace Vmmsharp
         /// <returns>true/false.</returns>
         public unsafe bool PrepareWriteStruct<T>(ulong qwA, T value)
             where T : unmanaged
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
         {
             uint cb = (uint)sizeof(T);
             byte* pb = (byte*)&value;
@@ -189,6 +192,9 @@ namespace Vmmsharp
         /// <returns>true/false.</returns>
         public unsafe bool ReadAs<T>(ulong qwA, out T result)
             where T : unmanaged
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
         {
             uint cb = (uint)sizeof(T);
             uint cbRead;
@@ -264,6 +270,6 @@ namespace Vmmsharp
             return Vmmi.VMMDLL_Scatter_Clear(hS, pid, flags);
         }
 
-        #endregion
+#endregion
     }
 }


### PR DESCRIPTION
- Allow vmm init without plugins
- Use better naming for Process/Pids functions/properties
- Dispose leechcore even with finalizer
- Support targeting NET9.0
- Support ref structs in .NET9+

BSD Zero Clause License

Copyright (C) 2025 by unseen7345

Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.

THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.